### PR TITLE
Allow duplicate characters in gallery

### DIFF
--- a/gallery.html
+++ b/gallery.html
@@ -13,9 +13,9 @@
     <a href="summon.html"><img src="assets/ui/summon.png" alt="Summon" title="Summon" /></a>
   </div>
   <script>
-    const collection = JSON.parse(localStorage.getItem("collection") || "{}");
+    const collection = JSON.parse(localStorage.getItem("collection") || "[]");
     const gallery = document.getElementById("gallery");
-    Object.values(collection).slice(0, 50).forEach((char) => {
+    collection.slice(0, 50).forEach((char) => {
       const item = document.createElement("div");
       item.classList.add("card");
 

--- a/script.js
+++ b/script.js
@@ -24,43 +24,6 @@ function pullCharacters(count) {
   return results;
 }
 
-function displayResults(results) {
-  const container = document.getElementById("result");
-  container.innerHTML = "";
-  const audio = document.getElementById("sfx");
-  audio.currentTime = 0;
-  audio.play();
-
-  const collection = JSON.parse(localStorage.getItem("collection") || "{}");
-
-  results.forEach(char => {
-    const card = document.createElement("div");
-    card.classList.add("card");
-
-    const img = document.createElement("img");
-    img.src = char.image;
-    img.style.borderColor = char.color;
-
-    const name = document.createElement("h3");
-    name.textContent = char.name;
-    name.style.color = char.color;
-
-    const rarity = document.createElement("p");
-    rarity.textContent = `Rarity: ${char.rarity}`;
-    rarity.style.color = char.color;
-
-    card.appendChild(img);
-    card.appendChild(name);
-    card.appendChild(rarity);
-    container.appendChild(card);
-
-    collection[char.name] = char;
-  });
-
-  localStorage.setItem("collection", JSON.stringify(collection));
-}
-
-
 let gems = parseInt(localStorage.getItem("gems") || "100000");
 const gemsElem = document.getElementById("gems");
 gemsElem.textContent = `💎 Gems: ${gems}`;
@@ -95,7 +58,7 @@ function displayResults(results) {
   audio.currentTime = 0;
   audio.play();
 
-  const collection = JSON.parse(localStorage.getItem("collection") || "{}");
+  const collection = JSON.parse(localStorage.getItem("collection") || "[]");
 
   results.forEach(char => {
     const card = document.createElement("div");
@@ -132,8 +95,7 @@ function displayResults(results) {
       card.style.opacity = 1;
     }, 100);
 
-    collection[char.name] = char;
+    collection.push(char);
   });
-
   localStorage.setItem("collection", JSON.stringify(collection));
 }


### PR DESCRIPTION
## Summary
- Preserve duplicate pulls by storing the collection as an array in localStorage
- Update gallery view to iterate over stored pulls so duplicates appear

## Testing
- `npm test` *(fails: Could not read package.json)*
- `node --check script.js`


------
https://chatgpt.com/codex/tasks/task_e_68a095d609bc832ab0d5e62fc894fb85